### PR TITLE
chore: add binarytargets for linux in schema prisma for Docker deployment

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,9 @@
 generator client {
   provider = "prisma-client-js"
   // engineType = "binary"  // Pour un environnement Edge
+    binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"] //permettra à Prisma de générer les binaires corrects pour votre environnement Docker Linux ARM64.
+
+
 }
 
 datasource db {


### PR DESCRIPTION
Erreur  à cause d'une incompatibilité entre l'architecture du système où Prisma Client a été généré et celle de votre environnement Docker.
Inclure linux-musl-arm64-openssl-3.0.x dans les cibles binaires 
binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
