### PR TITLE
feat: update metada layout and add sitemap and robot for google indexation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,11 +10,43 @@ const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   metadataBase: new URL(getCanonicalUrl()),
-  title: "Queer Cinema Database",
+  title: "Queer Cinema Database | Films et Archives LGBTQI+",
   description:
-    "Parcourez un catalogue mondial de films et archives LGBTQIA+, témoignant la diversité et la richesse des cinémas queer.",
+    "QueerCinema.fr : base de données mondiale dédiée aux films et archives LGBTQI+. Explorez la diversité et la richesse des cinémas queer.",
+  keywords: [
+    "cinéma queer",
+    "films LGBTQI+",
+    "archives LGBTQI+",
+    "queer cinema",
+    "cinéma LGBT",
+    "film LGBT",
+    "queer",
+    "LGBT",
+    "base de données cinéma",
+  ],
+  authors: [{ name: "QueerCinema" }],
+  creator: "QueerCinema",
+  publisher: "QueerCinema",
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
   openGraph: {
-    images: [`/assets/diary.svg`],
+    title: "Queer Cinema Database",
+    description:
+      "Base de données mondiale dédiée aux films et archives LGBTQI+. Explorez la diversité et la richesse des cinémas queer.",
+    url: getCanonicalUrl(),
+    siteName: "Queer Cinema",
+    images: ["/assets/diary.svg"],
+    locale: "fr_FR",
+    type: "website",
   },
   alternates: {
     canonical: "/",
@@ -27,7 +59,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="fr">
       <body
         className={`${inter.className} bg-white min-h-screen text-white flex flex-col`}
       >

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,44 @@
+import { MetadataRoute } from "next";
+import { getCanonicalUrl } from "@/utils/index";
+import { getMovies } from "./server-actions/movies/get-movies";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = getCanonicalUrl();
+
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/movies`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+  ];
+  // get movies dynamically
+  try {
+    const movies = await getMovies();
+
+    const moviePages: MetadataRoute.Sitemap = movies.map((movie) => ({
+      url: `${baseUrl}/movie/${movie.id}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    }));
+
+    return [...staticPages, ...moviePages];
+  } catch (error) {
+    console.error("Error when generating sitemap:", error);
+    return staticPages;
+  }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,15 @@
+User-agent: *
+Allow: /
+
+# Sitemap
+Sitemap: https://queercinema.fr/sitemap.xml
+
+# Optionnel : block folders
+Disallow: /account
+Disallow: /account/settings
+Disallow: /account/forgot-password
+Disallow: /account/forgot-password/confirmation
+Disallow: /account/reset-password
+Disallow: /login
+Disallow: /signup
+Disallow: /lists

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,5 +1,5 @@
 export const getCanonicalUrl = () => {
-  return process.env.NODE_ENV !== "production"
+  return process.env.NODE_ENV === "production"
     ? "https://queercinema.fr/"
     : "http://localhost:3000";
 };


### PR DESCRIPTION
Added SEO metadata including keywords, robots, openGraph, and twitter in layout.tsx for better search engine visibility.

Defined metadataBase and canonical URLs to improve link consistency across pages.

Created and configured a robots.txt file to allow full indexing while excluding private routes like /account/settings and /lists.

Improved sitemap generation by including both static pages (/, /movies, /about) and dynamic movie URLs.

Integrated the getMovies server action to fetch and include all individual movie pages in the sitemap.

Set specific priority and changeFrequency values for each route to guide search engine crawlers.

Ensured sitemap error resilience by falling back to static pages if movie data loading fails.